### PR TITLE
Fix compatibility with paho.mqtt.python >= 1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A command-line tool used for modbus RPC requests to [wb-mqtt-serial](https://github.com/wirenboard/wb-mqtt-serial). It provides abilities for sending Modbus requests to port and scan exists Modbus devices using "new-Modbus" feature.
 
 ## Modbus client
-Use `modbus_client_rpc` command to send a modbus request to the port. Arguments of command are fully compatible with [`modbus_client`]() arguments 
+Use `modbus_client_rpc` command to send a modbus request to the port. Arguments of command are fully compatible with [`modbus_client`](https://wirenboard.com/wiki/Modbus-client) arguments 
 Usage example:
 
     # modbus_client_rpc --debug -mrtu -pnone  /dev/ttyRS485-2 -a68 -t3 -r128 107

--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
 # Modbus-utils-RPC
 
-A command-line tool used for modbus RPC requests to [wb-mqtt-serial](https://github.com/wirenboard/wb-mqtt-serial).
+A command-line tool used for modbus RPC requests to [wb-mqtt-serial](https://github.com/wirenboard/wb-mqtt-serial). It provides abilities for sending Modbus requests to port and scan exists Modbus devices using "new-Modbus" feature.
 
-Some use cases:
- - Read coils ***-a 22 -r 10 -c 4 -f 0x01 tcp 4000 127.0.0.1***
- - Read discrete inputs ***-a 22 -r 10 -c 4 -f 0x02 rtu /dev/ttyRS485-1***
- - Write coil ***-a 22 -r 10 -f 0x05 -w "01" tcp 4000 127.0.0.1***
- - write multiple registers ***-a 22 -r 10 -f 0x10 -w "01AB 01D 01DD" rtu /dev/ttyRS485-2***
+## Modbus client
+Use `modbus_client_rpc` command to send a modbus request to the port. Arguments of command are fully compatible with [`modbus_client`]() arguments 
+Usage example:
 
+    # modbus_client_rpc --debug -mrtu -pnone  /dev/ttyRS485-2 -a68 -t3 -r128 107
+    SUCCESS: read 1 elements:
+	    Data: 0x0044 
+## Modbus scanner
+Use `modbus_scanner_rpc` for scan available devices with "new-Modbus" feature on the bus.
+Usage example:
+
+    # modbus_scanner_rpc /dev/ttyRS485-2
+    Found device with SN  fe124201 4262609409 modbus address  68
+
+Run `modbus_client_rpc` and `modbus_scanner_rpc` with `-h` option for detailed parameters description. 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+modbus-utils-rpc (1.1.2) stable; urgency=medium
+
+  * Fix compatibility with paho.mqtt.python >= 1.6.0
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 19 Oct 2022 16:11:02 +0300
+
 modbus-utils-rpc (1.1.1) stable; urgency=medium
 
   * Fix paho-mqtt version for bullseye

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 modbus-utils-rpc (1.1.2) stable; urgency=medium
 
   * Fix compatibility with paho.mqtt.python >= 1.6.0
+  * Update README
 
  -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 19 Oct 2022 16:11:02 +0300
 

--- a/debian/control
+++ b/debian/control
@@ -3,10 +3,10 @@ Maintainer: Ekaterina Volkova <ekaterina.volkova@wirenboard.ru>
 Section: python
 Priority: optional
 X-Python-Version: >= 3.5
-Build-Depends: python3, python3-setuptools, debhelper (>= 9), dh-python, python3-pytest, python3-umodbus (>=1.0.4-1+wb1), python3-paho-mqtt (<1.5.0), python3-mqttrpc(>=1.1.2), python3-six, python3-pytest-mock
+Build-Depends: python3, python3-setuptools, debhelper (>= 9), dh-python, python3-pytest, python3-umodbus (>=1.0.4-1+wb1), python3-paho-mqtt, python3-mqttrpc(>=1.1.2), python3-six, python3-pytest-mock
 Standards-Version: 3.9.1
 
 Package: python3-modbus-utils-rpc
 Architecture: all
-Depends: python3, ${misc:Depends}, python3-umodbus (>=1.0.4-1+wb1), python3-paho-mqtt (<1.6), python3-mqttrpc(>=1.1.2)
+Depends: python3, ${misc:Depends}, python3-umodbus (>=1.0.4-1+wb1), python3-paho-mqtt, python3-mqttrpc(>=1.1.2)
 Description: Wiren Board modbus utility using RPC (python 3)

--- a/modbus_client_rpc/main.py
+++ b/modbus_client_rpc/main.py
@@ -129,7 +129,7 @@ def create_rpc_request(args, get_port_params, modbus_message, response_size, tim
 @contextmanager
 def mqtt_client(name, broker=DEFAULT_BROKER):
     try:
-        client = mosquitto.Mosquitto(name)
+        client = mosquitto.Client(name)
         logger.debug("Connecting to broker %s:%s", broker["ip"], broker["port"])
         client.connect(broker["ip"], broker["port"])
         client.loop_start()

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -312,10 +312,10 @@ def test_send_message(mocker, send_message_context):
 
     mocker.patch("modbus_client_rpc.main.rpcclient.TMQTTRPCClient.call", test_rpc_call)
 
-    mocker.patch("modbus_client_rpc.main.mosquitto.Mosquitto.connect", test_connect)
-    mocker.patch("modbus_client_rpc.main.mosquitto.Mosquitto.loop_start")
-    mocker.patch("modbus_client_rpc.main.mosquitto.Mosquitto.loop_stop")
-    mocker.patch("modbus_client_rpc.main.mosquitto.Mosquitto.disconnect")
+    mocker.patch("modbus_client_rpc.main.mosquitto.Client.connect", test_connect)
+    mocker.patch("modbus_client_rpc.main.mosquitto.Client.loop_start")
+    mocker.patch("modbus_client_rpc.main.mosquitto.Client.loop_stop")
+    mocker.patch("modbus_client_rpc.main.mosquitto.Client.disconnect")
 
     if must_fail != "none":
         with pytest.raises(Exception):


### PR DESCRIPTION
Error:
```
AttributeError: module 'paho.mqtt.client' has no attribute 'Mosquitto'
```
https://github.com/wirenboard/modbus-utils-rpc/blob/d2b6a05ce869c667f5482faaa875c6c073b95adf/modbus_client_rpc/main.py#L132
From https://github.com/eclipse/paho.mqtt.python/blob/9782ab81fe7ee3a05e74c7f3e1d03d5611ea4be4/ChangeLog.txt#L37:
> v1.6.0 - 2021-10-20
> ...
> - Removed ancient Mosquitto compatibility class.

Related #6