### PR TITLE
Use mqtt client wrapper from wb-common

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+modbus-utils-rpc (1.1.4) stable; urgency=medium
+
+  * Use mqtt client wrapper from wb-common
+  * Support connection to Mosquitto through unix socket
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 28 Feb 2023 18:39:00 +0400
+
 modbus-utils-rpc (1.1.3) stable; urgency=medium
 
   * CI: change default build-target; enable python checks; make black & isort happier

--- a/debian/control
+++ b/debian/control
@@ -3,10 +3,10 @@ Maintainer: Ekaterina Volkova <ekaterina.volkova@wirenboard.ru>
 Section: python
 Priority: optional
 X-Python-Version: >= 3.5
-Build-Depends: python3, python3-setuptools, debhelper (>= 9), dh-python, python3-pytest, python3-umodbus (>=1.0.4-1+wb1), python3-paho-mqtt, python3-mqttrpc(>=1.1.2), python3-six, python3-pytest-mock
+Build-Depends: python3, python3-setuptools, debhelper (>= 9), dh-python, python3-pytest, python3-umodbus (>=1.0.4-1+wb1), python3-wb-common (>=2.1.0), python3-mqttrpc(>=1.1.2), python3-six, python3-pytest-mock
 Standards-Version: 3.9.1
 
 Package: python3-modbus-utils-rpc
 Architecture: all
-Depends: python3, ${misc:Depends}, python3-umodbus (>=1.0.4-1+wb1), python3-paho-mqtt, python3-mqttrpc(>=1.1.2), wb-mqtt-serial (>=2.74.0~~)
+Depends: python3, ${misc:Depends}, python3-umodbus (>=1.0.4-1+wb1), python3-wb-common (>=2.1.0), python3-mqttrpc(>=1.1.2), wb-mqtt-serial (>=2.74.0~~)
 Description: Wiren Board modbus utility using RPC (python 3)

--- a/modbus_client_rpc/main.py
+++ b/modbus_client_rpc/main.py
@@ -6,12 +6,13 @@ from contextlib import contextmanager
 from enum import IntEnum
 
 import umodbus.exceptions
-from modbus_client_rpc import exceptions
 from mqttrpc import client as rpcclient
 from umodbus import functions
 from umodbus.client import tcp
 from umodbus.client.serial import rtu
 from wb_common.mqtt_client import DEFAULT_BROKER_URL, MQTTClient
+
+from modbus_client_rpc import exceptions
 
 logger = logging.getLogger(__name__)
 
@@ -48,11 +49,6 @@ def parse_parity_or_tcpport(data):
         except ValueError as error:
             logger.error("Invalid value %s for -p option. Set {none|even|odd} or port number", data)
             raise error
-
-
-def parse_broker_host(data):
-    host = data.split(":")
-    return {"ip": host[0], "port": int(host[1])}
 
 
 def get_tcp_params(args):

--- a/modbus_client_rpc/main.py
+++ b/modbus_client_rpc/main.py
@@ -137,12 +137,12 @@ def mqtt_client(name, broker):
     try:
         client = MQTTClient(name, broker)
         logger.debug("Connecting to broker %s", broker)
-        client.connect()
+        client.start()
         yield client
     except (TimeoutError, ConnectionRefusedError) as error:
         raise exceptions.BrokerConnectionError from error
     finally:
-        client.disconnect()
+        client.stop()
 
 
 def send_message(args, broker, message, timeout):

--- a/modbus_client_rpc/main.py
+++ b/modbus_client_rpc/main.py
@@ -11,7 +11,7 @@ from mqttrpc import client as rpcclient
 from umodbus import functions
 from umodbus.client import tcp
 from umodbus.client.serial import rtu
-from wb_common.mqtt_client import MQTTClient
+from wb_common.mqtt_client import DEFAULT_BROKER_URL, MQTTClient
 
 logger = logging.getLogger(__name__)
 
@@ -406,7 +406,7 @@ def parse_options(argv=sys.argv):
         "--broker",
         help="Mqtt broker url",
         dest="mqtt_broker",
-        default="unix:///var/run/mosquitto/mosquitto.sock",
+        default=DEFAULT_BROKER_URL,
         type=str,
         required=False,
     )

--- a/modbus_scanner_rpc/main.py
+++ b/modbus_scanner_rpc/main.py
@@ -7,7 +7,7 @@ from modbus_client_rpc import exceptions
 from modbus_client_rpc import main as modbus_client
 from mqttrpc import client as rpcclient
 from umodbus.client.serial import redundancy_check
-from wb_common.mqtt_client import MQTTClient
+from wb_common.mqtt_client import DEFAULT_BROKER_URL, MQTTClient
 
 logger = logging.getLogger(__name__)
 
@@ -140,7 +140,7 @@ def main(argv=sys.argv):
         "--broker",
         help="Mqtt broker url",
         dest="mqtt_broker",
-        default="unix:///var/run/mosquitto/mosquitto.sock",
+        default=DEFAULT_BROKER_URL,
         type=str,
         required=False,
     )

--- a/modbus_scanner_rpc/main.py
+++ b/modbus_scanner_rpc/main.py
@@ -89,12 +89,12 @@ def mqtt_client(name, broker):
     try:
         client = MQTTClient(name, broker)
         logger.debug("Connecting to broker %s", broker)
-        client.connect()
+        client.start()
         yield client
     except (TimeoutError, ConnectionRefusedError, OSError) as error:
         raise exceptions.BrokerConnectionError from error
     finally:
-        client.disconnect()
+        client.stop()
 
 
 def scan_bus(args):

--- a/modbus_scanner_rpc/main.py
+++ b/modbus_scanner_rpc/main.py
@@ -1,15 +1,13 @@
 import argparse
 import logging
-import os
 import sys
 from contextlib import contextmanager
 
-import paho.mqtt.client as mqtt
-from mqttrpc import client as rpcclient
-from umodbus.client.serial import redundancy_check
-
 from modbus_client_rpc import exceptions
 from modbus_client_rpc import main as modbus_client
+from mqttrpc import client as rpcclient
+from umodbus.client.serial import redundancy_check
+from wb_common.mqtt_client import MQTTClient
 
 logger = logging.getLogger(__name__)
 
@@ -91,22 +89,20 @@ def continue_scan(serial_port, rpc_client, timeout):
 
 
 @contextmanager
-def mqtt_client(name, broker=modbus_client.DEFAULT_BROKER):
+def mqtt_client(name, broker):
     try:
-        client = mqtt.Client(name)
-        logger.debug("Connecting to broker %s:%s", broker["ip"], broker["port"])
-        client.connect(broker["ip"], broker["port"])
-        client.loop_start()
+        client = MQTTClient(name, broker)
+        logger.debug("Connecting to broker %s", broker)
+        client.connect()
         yield client
     except (TimeoutError, ConnectionRefusedError, OSError) as error:
         raise exceptions.BrokerConnectionError from error
     finally:
-        client.loop_stop()
         client.disconnect()
 
 
 def scan_bus(args):
-    with mqtt_client("modbus-scanner-rpc-%d" % os.getpid(), args.mqtt_broker) as client:
+    with mqtt_client("modbus-scanner-rpc", args.mqtt_broker) as client:
         try:
             rpc_client = rpcclient.TMQTTRPCClient(client)
             client.on_message = rpc_client.on_mqtt_message
@@ -142,10 +138,10 @@ def main(argv=sys.argv):
     )
     parser.add_argument(
         "--broker",
-        help="Mqtt broker IP:PORT",
+        help="Mqtt broker url",
         dest="mqtt_broker",
-        default=modbus_client.DEFAULT_BROKER,
-        type=parse_broker_host,
+        default="unix:///var/run/mosquitto/mosquitto.sock",
+        type=str,
         required=False,
     )
     parser.add_argument(

--- a/modbus_scanner_rpc/main.py
+++ b/modbus_scanner_rpc/main.py
@@ -3,11 +3,12 @@ import logging
 import sys
 from contextlib import contextmanager
 
-from modbus_client_rpc import exceptions
-from modbus_client_rpc import main as modbus_client
 from mqttrpc import client as rpcclient
 from umodbus.client.serial import redundancy_check
 from wb_common.mqtt_client import DEFAULT_BROKER_URL, MQTTClient
+
+from modbus_client_rpc import exceptions
+from modbus_client_rpc import main as modbus_client
 
 logger = logging.getLogger(__name__)
 
@@ -20,11 +21,6 @@ def remove_substring_prefix(prefix, string):
 
 def parse_hex_or_dec(data):
     return int(data, 0)
-
-
-def parse_broker_host(data):
-    host = data.split(":")
-    return {"ip": host[0], "port": int(host[1])}
 
 
 def create_rpc_request(serial_port, modbus_message, response_size, timeout):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -325,10 +325,10 @@ def test_send_message(mocker, send_message_context):
 
     mocker.patch("modbus_client_rpc.main.rpcclient.TMQTTRPCClient.call", test_rpc_call)
 
-    mocker.patch("modbus_client_rpc.main.mosquitto.Client.connect", test_connect)
-    mocker.patch("modbus_client_rpc.main.mosquitto.Client.loop_start")
-    mocker.patch("modbus_client_rpc.main.mosquitto.Client.loop_stop")
-    mocker.patch("modbus_client_rpc.main.mosquitto.Client.disconnect")
+    mocker.patch("modbus_client_rpc.main.MQTTClient.connect", test_connect)
+    mocker.patch("modbus_client_rpc.main.MQTTClient.loop_start")
+    mocker.patch("modbus_client_rpc.main.MQTTClient.loop_stop")
+    mocker.patch("modbus_client_rpc.main.MQTTClient.disconnect")
 
     if must_fail != "none":
         with pytest.raises(Exception):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -303,7 +303,7 @@ def test_send_message(mocker, send_message_context):
     expected_response = send_message_context[1]
     must_fail = send_message_context[2]
     request_timeout = 1000
-    args = {"mqtt_broker": main.DEFAULT_BROKER, "timeout": request_timeout}
+    args = {"mqtt_broker": "tcp://127.0.0.1:1883", "timeout": request_timeout}
 
     def test_rpc_call(self, driver, service, method, params, timeout=None):
         assert (
@@ -321,7 +321,7 @@ def test_send_message(mocker, send_message_context):
         return expected_response
 
     def test_connect(self, ip, port):
-        assert {"ip": ip, "port": port} == main.DEFAULT_BROKER
+        assert ip == "127.0.0.1" and port == 1883
 
     mocker.patch("modbus_client_rpc.main.rpcclient.TMQTTRPCClient.call", test_rpc_call)
 
@@ -409,7 +409,7 @@ test_argv_params_positive = [
             data_bits=8,
             stop_bits=2,
             parity_port="N",
-            mqtt_broker={"ip": "127.0.0.1", "port": 1883},
+            mqtt_broker="unix:///var/run/mosquitto/mosquitto.sock",
             serialport_host="/dev/ttyRS485-1",
             write_data=[10],
         ),
@@ -430,14 +430,14 @@ test_argv_params_positive = [
             data_bits=8,
             stop_bits=1,
             parity_port=1000,
-            mqtt_broker={"ip": "127.0.0.1", "port": 1883},
+            mqtt_broker="unix:///var/run/mosquitto/mosquitto.sock",
             serialport_host="192.168.10.4",
             write_data=[],
         ),
         [],
     ),
     (
-        ["test", "-mrtu", "-r10", "/dev/ttyRS485-1", "-a22", "-t0x05", "--broker", "192.168.10.6:1883"],
+        ["test", "-mrtu", "-r10", "/dev/ttyRS485-1", "-a22", "-t0x05", "--broker", "tcp://192.168.10.6:1883"],
         Namespace(
             debug=False,
             mode="rtu",
@@ -451,7 +451,7 @@ test_argv_params_positive = [
             data_bits=8,
             stop_bits=1,
             parity_port=None,
-            mqtt_broker={"ip": "192.168.10.6", "port": 1883},
+            mqtt_broker="tcp://192.168.10.6:1883",
             serialport_host="/dev/ttyRS485-1",
             write_data=[],
         ),


### PR DESCRIPTION
Depends on https://github.com/wirenboard/wb-common/pull/8

How to test:
```sh
$ modbus_client_rpc --debug -mrtu -a31 -c6 -r200 -t3 -b9600 -d8 -s2 -pnone /dev/ttyRS485-1
$ modbus_client_rpc --debug -mrtu -a31 -c6 -r200 -t3 -b9600 -d8 -s2 -pnone --broker unix:///var/run/mosquitto/mosquitto.sock /dev/ttyRS485-1
$ modbus_client_rpc --debug -mrtu -a31 -c6 -r200 -t3 -b9600 -d8 -s2 -pnone --broker tcp://127.0.0.1:1883 /dev/ttyRS485-1
$ modbus_client_rpc --debug -mrtu -a31 -c6 -r200 -t3 -b9600 -d8 -s2 -pnone --broker ws://127.0.0.1:18883 /dev/ttyRS485-1
$ modbus_scanner_rpc --debug /dev/ttyRS485-1
$ modbus_scanner_rpc --debug --broker unix:///var/run/mosquitto/mosquitto.sock /dev/ttyRS485-1
$ modbus_scanner_rpc --debug --broker tcp://127.0.0.1:1883 /dev/ttyRS485-1
$ modbus_scanner_rpc --debug --broker ws://127.0.0.1:18883 /dev/ttyRS485-1
```