### PR TITLE
modbus_scanner_rpc: scan on different port settings

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+modbus-utils-rpc (1.1.7) stable; urgency=medium
+
+  * modbus_scanner_rpc: scan on different port settings
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Min, 24 Apr 2023 17:21:00 +0400
+
 modbus-utils-rpc (1.1.6) stable; urgency=medium
 
   * modbus_scanner_rpc: fix error, when launched with -h arg


### PR DESCRIPTION
Before:
```sh
$ modbus_scanner_rpc /dev/ttyRS485-1
ERROR occurred
```
After:
```sh
$ modbus_scanner_rpc /dev/ttyRS485-1
Found device with SN 102525, modbus address 31, UART params <115200 8N2>
```