### PR TITLE
work via new wb-mqtt-serial rpc

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+modbus-utils-rpc (1.3.0) stable; urgency=medium
+
+  * work via new wb-mqtt-serial rpc
+  * implement RTU over TCP (i.e. transparent serial-TCP bridge) mode
+
+ -- Evgeny Boger <boger@wirenboard.com>  Fri, 25 Jul 2025 01:04:08 +0300
+
 modbus-utils-rpc (1.2.5) stable; urgency=medium
 
   * Fix lintian

--- a/modbus_client_rpc/main.py
+++ b/modbus_client_rpc/main.py
@@ -166,7 +166,7 @@ def get_modbus_rpc_payload_and_count(  # pylint:disable=too-many-arguments
     return msg_payload, register_count
 
 
-def create_rpc_request(
+def create_rpc_request( # pylint:disable=too-many-arguments
     args, modbus_mode, get_port_params, slave_addr, function, start_addr, register_count, payload_str, timeout
 ):
     rpc_request = get_port_params(args)

--- a/modbus_client_rpc/main.py
+++ b/modbus_client_rpc/main.py
@@ -90,11 +90,46 @@ def _check_address(address):
             f"Start address {address} exceeds maximum allowed value of 65535."
         )
 
+def get_rpc_register_count(function, write_data, read_count):
+    """Get the number of registers for the RPC call based on the function and data."""
+
+    if function in (functions.WRITE_SINGLE_COIL, functions.WRITE_SINGLE_REGISTER):
+        return 1
+
+    if function in (functions.WRITE_MULTIPLE_COILS, functions.WRITE_MULTIPLE_REGISTERS):
+        return len(write_data)
+
+    if not isinstance(read_count, int) or read_count <= 0:
+        raise exceptions.ModbusParametersError(
+            f"Invalid read count: {read_count}. It must be a positive integer."
+        )
+    return read_count
+
+def get_payload_for_write_coils(write_data):
+    """Convert write data for WRITE_MULTIPLE_COILS function to a bitmask string."""
+
+    write_data = [0 if x == 0 else 1 for x in write_data]
+    # Pack bits into bytes as bitmask
+    payload_bytes = []
+    for i in range(0, len(write_data), 8):
+        byte_val = 0
+        for j in range(8):
+            if i + j < len(write_data) and write_data[i + j]:
+                byte_val |= 1 << j
+        payload_bytes.append(byte_val)
+    return "".join(f"{x:02x}" for x in payload_bytes)
+
+def get_payload_for_single_coil(write_data):
+    """Convert write data for WRITE_SINGLE_COIL function to RPC call payload."""
+    if write_data[0] == 0:
+        return "0000"
+    else:
+        return "ff00"
 
 def get_modbus_rpc_payload_and_count(  # pylint:disable=too-many-arguments
     function, address_decrement, start_address, read_count, write_data
 ):
-    """Function accept modbus params and return payload string for and register count for wb-mqtt-serial RPC call
+    """Function accept modbus params and return payload string and register count for wb-mqtt-serial RPC call
 
     Returns:
         string: message
@@ -104,7 +139,6 @@ def get_modbus_rpc_payload_and_count(  # pylint:disable=too-many-arguments
     _check_address(start_address)
 
     msg_payload = ""
-    register_count = 0
 
     if address_decrement:
         start_address -= 1
@@ -118,37 +152,13 @@ def get_modbus_rpc_payload_and_count(  # pylint:disable=too-many-arguments
         logger.debug("Data to write: %s", "".join(f"0x{x:02x} " for x in write_data))
 
     if function == functions.WRITE_SINGLE_COIL:
-        write_data = [0 if x == 0 else 1 for x in write_data]
-        # Convert single coil to bitmask
-        if write_data[0] == 0:
-            msg_payload = "0000"
-        else:
-            msg_payload = "ff00"
+        msg_payload = get_payload_for_single_coil(write_data)
     elif function == functions.WRITE_MULTIPLE_COILS:
-        write_data = [0 if x == 0 else 1 for x in write_data]
-        # Pack bits into bytes as bitmask
-        payload_bytes = []
-        for i in range(0, len(write_data), 8):
-            byte_val = 0
-            for j in range(8):
-                if i + j < len(write_data) and write_data[i + j]:
-                    byte_val |= 1 << j
-            payload_bytes.append(byte_val)
-        msg_payload = "".join(f"{x:02x}" for x in payload_bytes)
+        msg_payload = get_payload_for_write_coils(write_data)
     else:
         msg_payload = "".join(f"{x:04x}" for x in write_data)
 
-    if function in (functions.WRITE_SINGLE_COIL, functions.WRITE_SINGLE_REGISTER):
-        register_count = 1
-    elif function in (functions.WRITE_MULTIPLE_COILS, functions.WRITE_MULTIPLE_REGISTERS):
-        register_count = len(write_data)
-    else:
-        if not isinstance(read_count, int) or read_count <= 0:
-            raise exceptions.ModbusParametersError(
-                f"Invalid read count: {read_count}. It must be a positive integer."
-            )
-        register_count = read_count
-
+    register_count = get_rpc_register_count(function, write_data, read_count)
     return msg_payload, register_count
 
 
@@ -383,8 +393,11 @@ def parse_options(argv=sys.argv):
     )
     parser.add_argument(
         "-t",
-        help="""Function type:
-(0x01) Read Coils, (0x02) Read Discrete Inputs, (0x05) Write Single Coil, (0x03) Read Holding Registers, (0x04) Read Input Registers, (0x06) Write Single Register, (0x0F) Write Multiple Coils, (0x10) Write Multiple Registers""",
+        help=(
+            "Function type: (0x01) Read Coils, (0x02) Read Discrete Inputs, (0x05) Write Single Coil, "
+            "(0x03) Read Holding Registers, (0x04) Read Input Registers, (0x06) Write Single Register, "
+            "(0x0F) Write Multiple Coils, (0x10) Write Multiple Registers"
+        ),
         type=parse_hex_or_dec,
         choices=[
             functions.READ_COILS,

--- a/modbus_client_rpc/main.py
+++ b/modbus_client_rpc/main.py
@@ -166,7 +166,7 @@ def get_modbus_rpc_payload_and_count(  # pylint:disable=too-many-arguments
     return msg_payload, register_count
 
 
-def create_rpc_request( # pylint:disable=too-many-arguments
+def create_rpc_request(  # pylint:disable=too-many-arguments
     args, modbus_mode, get_port_params, slave_addr, function, start_addr, register_count, payload_str, timeout
 ):
     rpc_request = get_port_params(args)

--- a/modbus_client_rpc/main.py
+++ b/modbus_client_rpc/main.py
@@ -90,6 +90,7 @@ def _check_address(address):
             f"Start address {address} exceeds maximum allowed value of 65535."
         )
 
+
 def get_rpc_register_count(function, write_data, read_count):
     """Get the number of registers for the RPC call based on the function and data."""
 
@@ -105,6 +106,7 @@ def get_rpc_register_count(function, write_data, read_count):
         )
     return read_count
 
+
 def get_payload_for_write_coils(write_data):
     """Convert write data for WRITE_MULTIPLE_COILS function to a bitmask string."""
 
@@ -119,12 +121,14 @@ def get_payload_for_write_coils(write_data):
         payload_bytes.append(byte_val)
     return "".join(f"{x:02x}" for x in payload_bytes)
 
+
 def get_payload_for_single_coil(write_data):
     """Convert write data for WRITE_SINGLE_COIL function to RPC call payload."""
     if write_data[0] == 0:
         return "0000"
     else:
         return "ff00"
+
 
 def get_modbus_rpc_payload_and_count(  # pylint:disable=too-many-arguments
     function, address_decrement, start_address, read_count, write_data

--- a/modbus_client_rpc/main.py
+++ b/modbus_client_rpc/main.py
@@ -8,8 +8,6 @@ from enum import IntEnum
 import umodbus.exceptions
 from mqttrpc import client as rpcclient
 from umodbus import functions
-from umodbus.client import tcp
-from umodbus.client.serial import rtu
 from wb_common.mqtt_client import DEFAULT_BROKER_URL, MQTTClient
 
 from modbus_client_rpc import exceptions
@@ -65,70 +63,115 @@ def get_rtu_params(args):
     }
 
 
-def create_modbus_message(  # pylint:disable=too-many-arguments
-    lib, function, slave_address, address_decrement, start_address, read_count, write_data
+def _check_function(function):
+    """Check if the function is valid for Modbus RPC calls."""
+    valid_functions = (
+        functions.READ_COILS,
+        functions.READ_DISCRETE_INPUTS,
+        functions.READ_HOLDING_REGISTERS,
+        functions.READ_INPUT_REGISTERS,
+        functions.WRITE_SINGLE_COIL,
+        functions.WRITE_SINGLE_REGISTER,
+        functions.WRITE_MULTIPLE_COILS,
+        functions.WRITE_MULTIPLE_REGISTERS,
+    )
+    if function not in valid_functions:
+        raise exceptions.ModbusParametersError(f"Invalid function type: {function}")
+
+
+def _check_address(address):
+    """Check if the address is a valid Modbus address."""
+    if not isinstance(address, int) or address < 0:
+        raise exceptions.ModbusParametersError(
+            f"Invalid start address: {address}. It must be a non-negative integer."
+        )
+    if address > 65535:
+        raise exceptions.ModbusParametersError(
+            f"Start address {address} exceeds maximum allowed value of 65535."
+        )
+
+
+def get_modbus_rpc_payload_and_count(  # pylint:disable=too-many-arguments
+    function, address_decrement, start_address, read_count, write_data
 ):
-    """Function accept modbus params and return tuple:
-    string type message with expected response size
+    """Function accept modbus params and return payload string for and register count for wb-mqtt-serial RPC call
 
     Returns:
         string: message
-        int: expected response size
     """
 
-    try:
-        if address_decrement:
-            start_address -= 1
+    _check_function(function)
+    _check_address(start_address)
 
-        if function in (
-            functions.WRITE_SINGLE_COIL,
-            functions.WRITE_SINGLE_REGISTER,
-            functions.WRITE_MULTIPLE_COILS,
-            functions.WRITE_MULTIPLE_REGISTERS,
-        ):
-            logger.debug("Data to write: %s", "".join(f"0x{x:02x} " for x in write_data))
+    msg_payload = ""
+    register_count = 0
 
-        if function in (functions.WRITE_SINGLE_COIL, functions.WRITE_MULTIPLE_COILS):
-            write_data = [0 if x == 0 else 1 for x in write_data]
+    if address_decrement:
+        start_address -= 1
 
-        if function == functions.READ_COILS:
-            message_byte = lib.read_coils(slave_address, start_address, read_count)
-        elif function == functions.READ_DISCRETE_INPUTS:
-            message_byte = lib.read_discrete_inputs(slave_address, start_address, read_count)
-        elif function == functions.READ_HOLDING_REGISTERS:
-            message_byte = lib.read_holding_registers(slave_address, start_address, read_count)
-        elif function == functions.READ_INPUT_REGISTERS:
-            message_byte = lib.read_input_registers(slave_address, start_address, read_count)
-        elif function == functions.WRITE_SINGLE_COIL:
-            message_byte = lib.write_single_coil(slave_address, start_address, write_data[0])
-        elif function == functions.WRITE_SINGLE_REGISTER:
-            message_byte = lib.write_single_register(slave_address, start_address, write_data[0])
-        elif function == functions.WRITE_MULTIPLE_COILS:
-            message_byte = lib.write_multiple_coils(slave_address, start_address, write_data)
-        elif function == functions.WRITE_MULTIPLE_REGISTERS:
-            message_byte = lib.write_multiple_registers(slave_address, start_address, write_data)
+    if function in (
+        functions.WRITE_SINGLE_COIL,
+        functions.WRITE_SINGLE_REGISTER,
+        functions.WRITE_MULTIPLE_COILS,
+        functions.WRITE_MULTIPLE_REGISTERS,
+    ):
+        logger.debug("Data to write: %s", "".join(f"0x{x:02x} " for x in write_data))
 
-        logger.debug("%s", "".join(f"[{x:02x}]" for x in message_byte))
+    if function == functions.WRITE_SINGLE_COIL:
+        write_data = [0 if x == 0 else 1 for x in write_data]
+        # Convert single coil to bitmask
+        if write_data[0] == 0:
+            msg_payload = "0000"
+        else:
+            msg_payload = "ff00"
+    elif function == functions.WRITE_MULTIPLE_COILS:
+        write_data = [0 if x == 0 else 1 for x in write_data]
+        # Pack bits into bytes as bitmask
+        payload_bytes = []
+        for i in range(0, len(write_data), 8):
+            byte_val = 0
+            for j in range(8):
+                if i + j < len(write_data) and write_data[i + j]:
+                    byte_val |= 1 << j
+            payload_bytes.append(byte_val)
+        msg_payload = "".join(f"{x:02x}" for x in payload_bytes)
+    else:
+        msg_payload = "".join(f"{x:04x}" for x in write_data)
 
-        message_str = "".join(f"{x:02x}" for x in message_byte)
-        response_size = lib.expected_response_size(message_byte)
+    if function in (functions.WRITE_SINGLE_COIL, functions.WRITE_SINGLE_REGISTER):
+        register_count = 1
+    elif function in (functions.WRITE_MULTIPLE_COILS, functions.WRITE_MULTIPLE_REGISTERS):
+        register_count = len(write_data)
+    else:
+        if not isinstance(read_count, int) or read_count <= 0:
+            raise exceptions.ModbusParametersError(
+                f"Invalid read count: {read_count}. It must be a positive integer."
+            )
+        register_count = read_count
 
-    except (struct.error, umodbus.exceptions.ModbusError, IndexError) as error:
-        raise exceptions.ModbusParametersError from error
-
-    return message_str, response_size
+    return msg_payload, register_count
 
 
-def create_rpc_request(args, get_port_params, modbus_message, response_size, timeout):
+def create_rpc_request(
+    args, modbus_mode, get_port_params, slave_addr, function, start_addr, register_count, payload_str, timeout
+):
     rpc_request = get_port_params(args)
     rpc_request.update(
         {
-            "response_size": response_size,
+            "slave_id": slave_addr,
+            "function": function,
+            "address": start_addr,
+            "count": register_count,
             "format": "HEX",
-            "msg": modbus_message,
+            "msg": payload_str,
             "total_timeout": timeout,
         }
     )
+    if modbus_mode == "tcp":
+        rpc_request["protocol"] = "modbus-tcp"
+    else:
+        rpc_request["protocol"] = "modbus"
+
     return rpc_request
 
 
@@ -167,28 +210,41 @@ def send_message(args, broker, message, timeout):
 
 
 def parse_rpc_response(response):
+    logger.debug("Response: %s", response)
     if "response" in response.keys():
         logger.debug("Response: %s", response["response"])
         return response["response"]
-    logger.debug("Response: %s", response)
+    if "exception" in response.keys():
+        logger.debug("Modbus error code=%d (%s)", response["exception"]["code"], response["exception"]["msg"])
+        raise umodbus.exceptions.error_code_to_exception_map[response["exception"]["code"]](
+            response["exception"]["msg"]
+        )
+
     raise exceptions.RPCError("Parse error", RPCErrorCode.E_RPC_PARSE_ERROR, '"response" field is missing')
 
 
-def parse_modbus_response(lib, function, request, response):
-
+def parse_modbus_response(function, register_count, response):
     try:
         response_byte = bytearray.fromhex(response)
-
         logger.debug("%s", "".join(f"<{x:02x}>" for x in response_byte))
 
-        data = lib.parse_response_adu(response_byte, bytearray.fromhex(request))
-
         if function in (functions.READ_COILS, functions.READ_DISCRETE_INPUTS):
+            # response_byte: bytearray(b'\x00\xFF')
+            # data: [0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1]
+            data = []
+            for byte in response_byte:
+                for bit in range(8):
+                    data.append((byte >> bit) & 1)
+                    if len(data) >= register_count:
+                        break
 
             print("SUCCESS: read", len(data), "elements:")
             print("\tData:", "".join(f"0x{x:02x} " for x in data))
 
         elif function in (functions.READ_HOLDING_REGISTERS, functions.READ_INPUT_REGISTERS):
+            # response_byte: bytearray(b'\x00\x0a\x00\x00')
+            # data: [0x000A, 0x0000]
+            data = [int.from_bytes(response_byte[i : i + 2], "big") for i in range(0, len(response_byte), 2)]
 
             print("SUCCESS: read", len(data), "elements:")
             print("\tData:", "".join(f"0x{x:04x} " for x in data))
@@ -196,7 +252,7 @@ def parse_modbus_response(lib, function, request, response):
         elif function in (functions.WRITE_SINGLE_COIL, functions.WRITE_SINGLE_REGISTER):
             print("SUCCESS: written 1 element")
         else:
-            print("SUCCESS: Coils/Registers written:", data)
+            print("SUCCESS: Coils/Registers written:", "?")
 
     except (struct.error, umodbus.exceptions.ModbusError) as error:
         raise exceptions.ModbusParseError(response_byte) from error
@@ -238,13 +294,11 @@ def handle_rpcerror(error):
     return ResultCode.OPERATION_ERROR
 
 
-def process_request(args, lib, get_port_params):
+def process_request(args, modbus_mode, get_port_params):
 
     try:
-        modbus_msg_str, modbus_resp_size = create_modbus_message(
-            lib,
+        payload_str, register_count = get_modbus_rpc_payload_and_count(
             args.func_type,
-            args.slave_addr,
             args.address_decrement,
             args.start_addr,
             args.read_count,
@@ -252,14 +306,21 @@ def process_request(args, lib, get_port_params):
         )
 
         rpc_request = create_rpc_request(
-            args, get_port_params, modbus_msg_str, modbus_resp_size, args.timeout
+            args,
+            modbus_mode,
+            get_port_params,
+            args.slave_addr,
+            args.func_type,
+            args.start_addr,
+            register_count,
+            payload_str,
+            args.timeout,
         )
 
         rpc_response = send_message(args, args.mqtt_broker, rpc_request, args.timeout)
 
         modbus_resp_str = parse_rpc_response(rpc_response)
-
-        parse_modbus_response(lib, args.func_type, modbus_msg_str, modbus_resp_str)
+        parse_modbus_response(args.func_type, register_count, modbus_resp_str)
 
         result_code = ResultCode.OK
 
@@ -290,9 +351,9 @@ def parse_options(argv=sys.argv):
     )
     parser.add_argument(
         "-m",
-        help="Mode",
+        help="Mode: Modbus TCP, Modbus RTU or Modbus RTU over TCP (transparent serial port <-> TCP bridge)",
         type=str,
-        choices=["tcp", "rtu"],
+        choices=["tcp", "rtu", "rtuovertcp"],
         dest="mode",
         required=True,
     )
@@ -322,7 +383,8 @@ def parse_options(argv=sys.argv):
     )
     parser.add_argument(
         "-t",
-        help="Function type",
+        help="""Function type:
+(0x01) Read Coils, (0x02) Read Discrete Inputs, (0x05) Write Single Coil, (0x03) Read Holding Registers, (0x04) Read Input Registers, (0x06) Write Single Register, (0x0F) Write Multiple Coils, (0x10) Write Multiple Registers""",
         type=parse_hex_or_dec,
         choices=[
             functions.READ_COILS,
@@ -449,18 +511,16 @@ def main(argv=sys.argv):
     logger.addHandler(stream_handler)
     logger.setLevel(logger_level)
 
-    if options.mode == "tcp":
+    if options.mode in ("tcp", "rtuovertcp"):
         if options.parity_port is None:
             options.parity_port = 502
         get_port_params = get_tcp_params
-        lib = tcp
     else:
         if options.parity_port is None:
             options.parity_port = "none"
         get_port_params = get_rtu_params
-        lib = rtu
 
-    return process_request(options, lib, get_port_params)
+    return process_request(options, options.mode, get_port_params)
 
 
 if __name__ == "__main__":

--- a/modbus_client_rpc/main.py
+++ b/modbus_client_rpc/main.py
@@ -124,10 +124,7 @@ def get_payload_for_write_coils(write_data):
 
 def get_payload_for_single_coil(write_data):
     """Convert write data for WRITE_SINGLE_COIL function to RPC call payload."""
-    if write_data[0] == 0:
-        return "0000"
-    else:
-        return "ff00"
+    return "0000" if write_data[0] == 0 else "ff00"
 
 
 def get_modbus_rpc_payload_and_count(  # pylint:disable=too-many-arguments

--- a/tests/test_modbus_client.py
+++ b/tests/test_modbus_client.py
@@ -9,242 +9,126 @@ from modbus_client_rpc import main
 
 test_modbus_parameters = [
     (
-        main.rtu,
         0x01,
-        0,
         False,
         0,
         1,
         [],
-        "000100000001fc1b",
-        6,
+        "",
+        1,
         False,
     ),
     (
-        main.rtu,
         0x02,
-        247,
         False,
         65535,
         1,
         [],
-        "f702ffff0001ad78",
-        6,
+        "",
+        1,
         False,
     ),
     (
-        main.rtu,
         0x03,
-        0,
         False,
         0,
         125,
         [],
-        "00030000007d843a",
-        255,
-        False,
-    ),
-    (
-        main.rtu,
-        0x04,
-        247,
-        True,
-        65535,
-        2,
-        [],
-        "f704fffe000234b9",
-        9,
-        False,
-    ),
-    (
-        main.rtu,
-        0x05,
-        0,
-        False,
-        65535,
-        0,
-        [255],
-        "0005ffffff008dcf",
-        8,
-        False,
-    ),
-    (
-        main.rtu,
-        0x06,
-        247,
-        True,
-        65535,
-        0,
-        [22950],
-        "f706fffe59a67692",
-        8,
-        False,
-    ),
-    (
-        main.rtu,
-        0x0F,
-        0,
-        False,
-        0,
-        0,
-        [0, 255, 0, 100, 0, 50],
-        "000f00000006012adf45",
-        8,
-        False,
-    ),
-    (
-        main.rtu,
-        0x10,
-        247,
-        False,
-        65533,
-        0,
-        [22950, 15406, 4658],
-        "f710fffd00030659a63c2e1232ed65",
-        8,
-        False,
-    ),
-    (
-        main.tcp,
-        0x01,
-        0,
-        False,
-        0,
-        1,
-        [],
-        "000000000006000100000001",
-        10,
-        False,
-    ),
-    (
-        main.tcp,
-        0x02,
-        247,
-        False,
-        65535,
-        1,
-        [],
-        "000000000006f702ffff0001",
-        10,
-        False,
-    ),
-    (
-        main.tcp,
-        0x03,
-        0,
-        False,
-        0,
+        "",
         125,
-        [],
-        "00000000000600030000007d",
-        259,
         False,
     ),
     (
-        main.tcp,
         0x04,
-        247,
         True,
         65535,
         2,
         [],
-        "000000000006f704fffe0002",
-        13,
+        "",
+        2,
         False,
     ),
     (
-        main.tcp,
         0x05,
-        0,
         False,
         65535,
         0,
         [255],
-        "0000000000060005ffffff00",
-        12,
+        "ff00",
+        1,
         False,
     ),
     (
-        main.tcp,
         0x06,
-        247,
         True,
         65535,
         0,
         [22950],
-        "000000000006f706fffe59a6",
-        12,
+        "59a6",
+        1,
         False,
     ),
     (
-        main.tcp,
         0x0F,
-        0,
         False,
         0,
         0,
         [0, 255, 0, 100, 0, 50],
-        "000000000008000f00000006012a",
-        12,
+        "2a",
+        6,
         False,
     ),
     (
-        main.tcp,
         0x10,
-        247,
         False,
         65533,
         0,
         [22950, 15406, 4658],
-        "00000000000df710fffd00030659a63c2e1232",
-        12,
+        "59a63c2e1232",
+        3,
         False,
     ),
-    (main.rtu, 0x07, 0, False, 0, 0, [], "", 0, True),
-    (main.rtu, 0x01, 250, False, 0, 0, [], "", 0, True),
-    (main.rtu, 0x01, 0, False, 65536, 0, [], "", 0, True),
-    (main.rtu, 0x01, 0, True, 0, 0, [], "", 0, True),
-    (main.rtu, 0x01, 0, True, 0, 126, [], "", 0, True),
-    (main.rtu, 0x01, 0, True, 0, 0, [], "", 0, True),
+    (0x07, False, 0, 0, [], "", 0, True),
+    (0x01, False, 0, 0, [], "", 0, True),
+    (0x01, False, 65536, 0, [], "", 0, True),
+    (0x01, True, 0, 0, [], "", 0, True),
+    (0x01, True, 0, 126, [], "", 126, False),  # it's fun, but reading 125 *coils* is actually allowed
+    (0x01, True, 0, 0, [], "", 0, True),
 ]
 
 
 @pytest.mark.parametrize(
-    "lib, function, slave_address, address_decrement, start_address, read_count, write_data, expected_message, expected_length,must_fail",
+    "function, address_decrement, start_address, read_count, write_data, expected_rpc_payload, expected_rpc_count,must_fail",
     test_modbus_parameters,
 )
-def test_create_modbus_message(  # pylint:disable=too-many-arguments
-    lib,
+def test_get_modbus_rpc_payload(  # pylint:disable=too-many-arguments
     function,
-    slave_address,
     address_decrement,
     start_address,
     read_count,
     write_data,
-    expected_message,
-    expected_length,
+    expected_rpc_payload,
+    expected_rpc_count,
     must_fail,
 ):
 
     if must_fail:
         with pytest.raises(Exception):
-            message, length = main.create_modbus_message(
-                lib, function, slave_address, address_decrement, start_address, read_count, write_data
+            message, length = main.get_modbus_rpc_payload_and_count(
+                function, address_decrement, start_address, read_count, write_data
             )
     else:
-        message, length = main.create_modbus_message(
-            lib, function, slave_address, address_decrement, start_address, read_count, write_data
+        message, length = main.get_modbus_rpc_payload_and_count(
+            function, address_decrement, start_address, read_count, write_data
         )
-
-        if lib == main.rtu:
-            assert (expected_message, expected_length) == (message, length)
-        elif lib == main.tcp:
-            assert (expected_message[4:], expected_length) == (message[4:], length)
+        assert (expected_rpc_payload, expected_rpc_count) == (message, length)
 
 
 test_rpc_param = [
     (
         main.get_rtu_params,
+        "rtu",
+        "modbus",
         {
             "serialport_host": "rtu_path",
             "baudrate": 9600,
@@ -262,17 +146,31 @@ test_rpc_param = [
     ),
     (
         main.get_tcp_params,
+        "tcp",
+        "modbus-tcp",
+        {"serialport_host": "tcp_path", "parity_port": 1000},
+        {"ip": "tcp_path", "port": 1000},
+    ),
+    (
+        main.get_tcp_params,
+        "rtuovertcp",
+        "modbus",
         {"serialport_host": "tcp_path", "parity_port": 1000},
         {"ip": "tcp_path", "port": 1000},
     ),
 ]
 
 
-@pytest.mark.parametrize("get_path_function, options, expected_path", test_rpc_param)
-def test_create_rpc_request(get_path_function, options, expected_path):
-    test_message = "message"
-    test_response_size = 10
-    test_timeout = 10000
+@pytest.mark.parametrize(
+    "get_path_function, modbus_mode, rpc_protocol, options, expected_path", test_rpc_param
+)
+def test_create_rpc_request(get_path_function, modbus_mode, rpc_protocol, options, expected_path):
+    test_message = "01020304"
+    test_slave_addr = 123
+    test_func_type = 0x10
+    test_start_addr = 200
+    test_register_count = 2
+    test_timeout = 5000
 
     def test_get_path_function(options):
         path = get_path_function(options)
@@ -280,10 +178,25 @@ def test_create_rpc_request(get_path_function, options, expected_path):
         return path
 
     request = main.create_rpc_request(
-        Namespace(**options), test_get_path_function, test_message, test_response_size, test_timeout
+        Namespace(**options),
+        modbus_mode,
+        test_get_path_function,
+        test_slave_addr,
+        test_func_type,
+        test_start_addr,
+        test_register_count,
+        test_message,
+        test_timeout,
     )
 
-    assert (request["format"], request["msg"], request["response_size"]) == ("HEX", "message", 10)
+    assert request["format"] == "HEX"
+    assert request["msg"] == test_message
+    assert request["slave_id"] == test_slave_addr
+    assert request["function"] == test_func_type
+    assert request["address"] == test_start_addr
+    assert request["count"] == test_register_count
+    assert request["protocol"] == rpc_protocol
+    assert request["total_timeout"] == test_timeout
 
 
 test_send_message_params = [
@@ -370,18 +283,18 @@ def test_parse_rpc_response(rpc_response, must_fail):
 
 
 test_modbus_response_params = [
-    (main.rtu, 0x01, "1604010e000152d2", "160402fe348c84", False),
-    (main.rtu, 0x01, "1604010e000152d2", "160402fe348c80", True),
+    (0x01, 8, "fe34", False),
+    (0x03, 2, "000a0000", False),
 ]
 
 
-@pytest.mark.parametrize("lib, function, modrequest, response, must_fail", test_modbus_response_params)
-def test_parse_modbus_response(lib, function, modrequest, response, must_fail):
+@pytest.mark.parametrize("function, register_count, response, must_fail", test_modbus_response_params)
+def test_parse_modbus_response(function, register_count, response, must_fail):
     if must_fail:
         with pytest.raises(Exception):
-            main.parse_modbus_response(lib, function, modrequest, response)
+            main.parse_modbus_response(function, register_count, response)
     else:
-        main.parse_modbus_response(lib, function, modrequest, response)
+        main.parse_modbus_response(function, register_count, response)
 
 
 test_argv_params_positive = [
@@ -492,39 +405,44 @@ def test_main(mocker, main_context):
     test_argv = main_context[0]
     test_options = main_context[1]
 
-    test_modbus_message = [0x01, 0x02, 0x03]
-    test_response_size = 5
+    test_payload_str = "01020304"
+    test_register_count = 5
     test_rpc_request = {"message": "request"}
-    test_rpc_response = {"message": "response"}
-    test_modbus_response = [0x04, 0x05, 0x06]
+    test_rpc_response = {"response": "040506"}
 
     def parse_options(argv):
         assert argv == test_argv[1:]
         return test_options, []
 
-    def create_modbus_message(  # pylint:disable=too-many-arguments
-        lib, function, slave_address, address_decrement, start_address, read_count, write_data
-    ):
-        if test_options.mode == "rtu":
-            assert lib == main.rtu
-        else:
-            assert lib == main.tcp
+    def get_modbus_rpc_payload_and_count(function, address_decrement, start_address, read_count, write_data):
         assert function == test_options.func_type
-        assert slave_address == test_options.slave_addr
         assert address_decrement == test_options.address_decrement
         assert start_address == test_options.start_addr
         assert read_count == test_options.read_count
         assert write_data == test_options.write_data
-        return test_modbus_message, test_response_size
+        return test_payload_str, test_register_count
 
-    def create_rpc_request(args, get_port_params, modbus_message, response_size, timeout):
+    def create_rpc_request(
+        args,
+        modbus_mode,
+        get_port_params,
+        slave_addr,
+        function,
+        start_addr,
+        register_count,
+        payload_str,
+        timeout,
+    ):
         assert args == test_options
         if test_options.mode == "rtu":
             assert get_port_params == main.get_rtu_params  # pylint:disable=comparison-with-callable
         else:
             assert get_port_params == main.get_tcp_params  # pylint:disable=comparison-with-callable
-        assert modbus_message == test_modbus_message
-        assert response_size == test_response_size
+        assert slave_addr == test_options.slave_addr
+        assert function == test_options.func_type
+        assert start_addr == test_options.start_addr
+        assert register_count == test_register_count
+        assert payload_str == test_payload_str
         assert timeout == test_options.timeout
         return test_rpc_request
 
@@ -537,19 +455,15 @@ def test_main(mocker, main_context):
 
     def parse_rpc_response(response):
         assert response == test_rpc_response
-        return test_modbus_response
+        return "040506"
 
-    def parse_modbus_response(lib, function, request, response):
-        if test_options.mode == "rtu":
-            assert lib == main.rtu
-        else:
-            assert lib == main.tcp
+    def parse_modbus_response(function, register_count, response):
         assert function == test_options.func_type
-        assert request == test_modbus_message
-        assert response == test_modbus_response
+        assert register_count == test_register_count
+        assert response == "040506"
 
     mocker.patch("modbus_client_rpc.main.parse_options", parse_options)
-    mocker.patch("modbus_client_rpc.main.create_modbus_message", create_modbus_message)
+    mocker.patch("modbus_client_rpc.main.get_modbus_rpc_payload_and_count", get_modbus_rpc_payload_and_count)
     mocker.patch("modbus_client_rpc.main.create_rpc_request", create_rpc_request)
     mocker.patch("modbus_client_rpc.main.send_message", send_message)
     mocker.patch("modbus_client_rpc.main.parse_rpc_response", parse_rpc_response)

--- a/tests/test_modbus_client.py
+++ b/tests/test_modbus_client.py
@@ -422,7 +422,7 @@ def test_main(mocker, main_context):
         assert write_data == test_options.write_data
         return test_payload_str, test_register_count
 
-    def create_rpc_request(
+    def create_rpc_request(  # pylint:disable=too-many-arguments
         args,
         modbus_mode,
         get_port_params,


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Работаем через "новый" API wb-mqtt-serial Port/Load, чтобы он знал про протокол Modbus

___________________________________
**Что поменялось для пользователей:**

Стало быстрее. Собственно главная причина поддержки модбаса в Port/Load была в том, что можно хитро читать из порта, т.к. мы знаем сколько байтиков мы ожидаем в ответе.

Ну, ещё добавился режим RTU-over-TCP нахаляву (справедливости ради, он и без нового RPC бы добавлялся в две строчки), и в хелп немножко добавил полезного.

___________________________________
**Как проверял/а:**

Запускал с обычным wb-mqtt-serial, с патченным (см. свежий PR туда). Читал через него с mbgate и с обычных настоящих устройств.
